### PR TITLE
Extend CLI commands, add new ones

### DIFF
--- a/SoftLayer/CLI/hardware/list.py
+++ b/SoftLayer/CLI/hardware/list.py
@@ -2,6 +2,7 @@
 # :license: MIT, see LICENSE for more details.
 
 import click
+import json
 
 import SoftLayer
 from SoftLayer.CLI import columns as column_helper
@@ -61,9 +62,10 @@ DEFAULT_COLUMNS = [
               % ', '.join(column.name for column in COLUMNS),
               default=','.join(DEFAULT_COLUMNS),
               show_default=True)
+@click.option('--output-json', is_flag=True, default=False)
 @environment.pass_env
 def cli(env, sortby, cpu, domain, datacenter, hostname, memory, network, tag,
-        columns):
+        columns, output_json):
     """List hardware servers."""
 
     manager = SoftLayer.HardwareManager(env.client)
@@ -77,6 +79,9 @@ def cli(env, sortby, cpu, domain, datacenter, hostname, memory, network, tag,
                                     tags=tag,
                                     mask=columns.mask())
 
+    if output_json:
+        env.fout(json.dumps({'hardware': servers}))
+        return
     table = formatting.Table(columns.columns)
     table.sortby = sortby
 

--- a/SoftLayer/CLI/hardware/status.py
+++ b/SoftLayer/CLI/hardware/status.py
@@ -1,0 +1,16 @@
+import click
+import json
+
+import SoftLayer
+from SoftLayer.CLI import environment
+
+
+@click.command()
+@click.argument('order_id', required=True)
+@environment.pass_env
+def cli(env, order_id):
+    hardware = SoftLayer.HardwareManager(env.client)
+
+    env.fout(json.dumps({
+        'statuses': hardware.get_hardware_status_from_order(order_id)
+    }))

--- a/SoftLayer/CLI/nas/detail.py
+++ b/SoftLayer/CLI/nas/detail.py
@@ -1,0 +1,19 @@
+import click
+import json
+
+from SoftLayer.CLI import environment
+from SoftLayer.CLI import formatting
+from SoftLayer import utils
+
+NAS_PROPERTIES = 'id,username,serviceResourceBackendIpAddress'
+
+
+@click.command()
+@click.argument('nasid', type=int)
+@environment.pass_env
+def cli(env, nasid):
+    account = env.client['Account']
+    for nas in account.getNasNetworkStorage(mask=NAS_PROPERTIES):
+        if int(nas['id']) == nasid:
+            env.fout(json.dumps(nas))
+            break

--- a/SoftLayer/CLI/nas/grant_access.py
+++ b/SoftLayer/CLI/nas/grant_access.py
@@ -1,0 +1,23 @@
+import click
+import json
+
+import SoftLayer
+from SoftLayer.CLI import environment
+from SoftLayer.CLI import formatting
+from SoftLayer.CLI import hardware
+
+STORAGE_ENDPOINT = 'SoftLayer_Network_Storage'
+
+@click.command()
+@click.option('--order-id', required=True)
+@click.option('--storage-id', required=True)
+@environment.pass_env
+def cli(env, order_id, storage_id):
+    hardware = SoftLayer.HardwareManager(env.client)
+
+    hardware_ids = hardware.get_hardware_ids(order_id)
+    for hardware_id in hardware_ids:
+        payload = {'id': hardware_id}
+        env.client[STORAGE_ENDPOINT].allowAccessFromHardware(
+            payload, id=storage_id
+        )

--- a/SoftLayer/CLI/nas/revoke_access.py
+++ b/SoftLayer/CLI/nas/revoke_access.py
@@ -1,0 +1,23 @@
+import click
+import json
+
+import SoftLayer
+from SoftLayer.CLI import environment
+from SoftLayer.CLI import formatting
+from SoftLayer.CLI import hardware
+
+STORAGE_ENDPOINT = 'SoftLayer_Network_Storage'
+
+@click.command()
+@click.option('--order-id', required=True)
+@click.option('--storage-id', required=True)
+@environment.pass_env
+def cli(env, order_id, storage_id):
+    hardware = SoftLayer.HardwareManager(env.client)
+
+    hardware_ids = hardware.get_hardware_ids(order_id)
+    for hardware_id in hardware_ids:
+        payload = {'id': hardware_id}
+        env.client[STORAGE_ENDPOINT].removeAccessFromHardware(
+            payload, id=storage_id
+        )

--- a/SoftLayer/CLI/routes.py
+++ b/SoftLayer/CLI/routes.py
@@ -166,6 +166,8 @@ ALL_ROUTES = [
     ('nas', 'SoftLayer.CLI.nas'),
     ('nas:list', 'SoftLayer.CLI.nas.list:cli'),
     ('nas:credentials', 'SoftLayer.CLI.nas.credentials:cli'),
+    ('nas:grant-access', 'SoftLayer.CLI.nas.grant_access:cli'),
+    ('nas:detail', 'SoftLayer.CLI.nas.detail:cli'),
 
     ('object-storage', 'SoftLayer.CLI.object_storage'),
     ('object-storage:accounts',
@@ -192,6 +194,7 @@ ALL_ROUTES = [
     ('hardware:reload', 'SoftLayer.CLI.hardware.reload:cli'),
     ('hardware:credentials', 'SoftLayer.CLI.hardware.credentials:cli'),
     ('hardware:update-firmware', 'SoftLayer.CLI.hardware.update_firmware:cli'),
+    ('hardware:status', 'SoftLayer.CLI.hardware.status:cli'),
 
     ('snapshot', 'SoftLayer.CLI.snapshot'),
     ('snapshot:cancel', 'SoftLayer.CLI.snapshot.cancel:cli'),

--- a/SoftLayer/managers/ordering.py
+++ b/SoftLayer/managers/ordering.py
@@ -199,3 +199,9 @@ class OrderingManager(object):
         container = self.generate_order_template(quote_id, extra,
                                                  quantity=quantity)
         return self.client['Product_Order'].placeOrder(container)
+
+    def get_order(self, order_id, mask=None):
+        return self.client['Billing_Order'].getObject(
+            id=order_id,
+            mask=mask
+        )


### PR DESCRIPTION
New commands:
- nas grant-access
- nas revoke-access
- nas detail
- hardware status (status based on orderId rather than hardwareId)

Updated commands:
- hardware detail: parse out specific fields json format
- hardware create: create multiple servers

janky --output-json flag to dump specific parts in JSON
TODO: revert some commands to use existing --format=json flag