### PR TITLE
some boilerplate cancel confirmation was causing an abort for dedicatedhost cancel

### DIFF
--- a/SoftLayer/CLI/dedicatedhost/cancel.py
+++ b/SoftLayer/CLI/dedicatedhost/cancel.py
@@ -26,8 +26,4 @@ def cli(env, identifier, immediate, comment, reason):
 
     mgr = SoftLayer.DedicatedHostManager(env.client)
     host_id = helpers.resolve_id(mgr.resolve_ids, identifier, 'dedicatedhost')
-
-    if not (env.skip_confirmations or formatting.no_going_back(host_id)):
-        raise exceptions.CLIAbort('Aborted')
-
     mgr.cancel_host(host_id, reason, comment, immediate)


### PR DESCRIPTION
just remove the confirmation and other checks, we just want to kill the thing