### PR TITLE
Remove more junk from dedicatedhost cancel command

### DIFF
--- a/SoftLayer/CLI/dedicatedhost/cancel.py
+++ b/SoftLayer/CLI/dedicatedhost/cancel.py
@@ -25,5 +25,4 @@ def cli(env, identifier, immediate, comment, reason):
     """Cancel a dedicated server."""
 
     mgr = SoftLayer.DedicatedHostManager(env.client)
-    host_id = helpers.resolve_id(mgr.resolve_ids, identifier, 'dedicatedhost')
-    mgr.cancel_host(host_id, reason, comment, immediate)
+    mgr.cancel_host(identifier, reason, comment, immediate)

--- a/SoftLayer/managers/dedicated_host.py
+++ b/SoftLayer/managers/dedicated_host.py
@@ -70,7 +70,6 @@ class DedicatedHostManager(utils.IdentifierMixin, object):
 
         result = self.client.call('Billing_Item', 'cancelItem',
                                   immediate, False, cancel_reason, comment, id=billing_id)
-        host_billing = self.get_host(host_id, mask=mask)
 
         return result
 


### PR DESCRIPTION
not sure what resolve_ids function was doing besides throwing exceptions but cancel seems to work fine without it