### PR TITLE
dedicatedhost Edit and show tags

### DIFF
--- a/SoftLayer/CLI/dedicatedhost/cancel.py
+++ b/SoftLayer/CLI/dedicatedhost/cancel.py
@@ -14,14 +14,14 @@ from SoftLayer.CLI import helpers
 @click.argument('identifier')
 @click.option('--immediate',
               is_flag=True,
-              default=False,
+              default=True,
               help="Cancels the server immediately (instead of on the billing anniversary)")
 @click.option('--comment',
               help="An optional comment to add to the cancellation ticket")
 @click.option('--reason',
               help="An optional cancellation reason. See cancel-reasons for a list of available options")
 @environment.pass_env
-def cli(env, identifier, immediate, comment, reason):
+def cli(env, identifier, comment, reason, immediate=True):
     """Cancel a dedicated server."""
 
     mgr = SoftLayer.DedicatedHostManager(env.client)

--- a/SoftLayer/CLI/dedicatedhost/detail.py
+++ b/SoftLayer/CLI/dedicatedhost/detail.py
@@ -40,6 +40,7 @@ def cli(env, identifier, price=False, guests=False):
     table.add_row(['router hostname', result['backendRouter']['hostname']])
     table.add_row(['owner', formatting.FormattedItem(
         utils.lookup(result, 'billingItem', 'orderItem', 'order', 'userRecord', 'username') or formatting.blank(),)])
+    table.add_row(['tags', formatting.tags(result['tagReferences'])])
 
     if price:
         total_price = utils.lookup(result,

--- a/SoftLayer/CLI/dedicatedhost/edit.py
+++ b/SoftLayer/CLI/dedicatedhost/edit.py
@@ -1,0 +1,61 @@
+"""Edit dedicated host details."""
+# :license: MIT, see LICENSE for more details.
+
+import click
+
+import SoftLayer
+from SoftLayer.CLI import environment
+from SoftLayer.CLI import exceptions
+from SoftLayer.CLI import helpers
+
+
+@click.command()
+@click.argument('identifier')
+@click.option('--domain', '-D', help="Domain portion of the FQDN")
+@click.option('--userfile', '-F',
+              help="Read userdata from file",
+              type=click.Path(exists=True, readable=True, resolve_path=True))
+@click.option('--tag', '-g',
+              multiple=True,
+              help="Tags to set or empty string to remove all")
+@click.option('--hostname', '-H', help="Host portion of the FQDN")
+@click.option('--userdata', '-u', help="User defined metadata string")
+@click.option('--public-speed',
+              help="Public port speed.",
+              default=None,
+              type=click.Choice(['0', '10', '100', '1000', '10000']))
+@click.option('--private-speed',
+              help="Private port speed.",
+              default=None,
+              type=click.Choice(['0', '10', '100', '1000', '10000']))
+@environment.pass_env
+def cli(env, identifier, domain, userfile, tag, hostname, userdata,
+        public_speed, private_speed):
+    """Edit dedicated host details."""
+
+    if userdata and userfile:
+        raise exceptions.ArgumentError(
+            '[-u | --userdata] not allowed with [-F | --userfile]')
+
+    data = {
+        'hostname': hostname,
+        'domain': domain,
+    }
+    if userdata:
+        data['userdata'] = userdata
+    elif userfile:
+        with open(userfile, 'r') as userfile_obj:
+            data['userdata'] = userfile_obj.read()
+    if tag:
+        data['tags'] = ','.join(tag)
+
+    mgr = SoftLayer.DedicatedHostManager(env.client)
+
+    if not mgr.edit(identifier, **data):
+        raise exceptions.CLIAbort("Failed to update dedicated host")
+
+    if public_speed is not None:
+        mgr.change_port_speed(identifier, True, int(public_speed))
+
+    if private_speed is not None:
+        mgr.change_port_speed(identifier, False, int(private_speed))

--- a/SoftLayer/CLI/routes.py
+++ b/SoftLayer/CLI/routes.py
@@ -37,6 +37,7 @@ ALL_ROUTES = [
     ('dedicatedhost:create-options', 'SoftLayer.CLI.dedicatedhost.create_options:cli'),
     ('dedicatedhost:detail', 'SoftLayer.CLI.dedicatedhost.detail:cli'),
     ('dedicatedhost:cancel', 'SoftLayer.CLI.dedicatedhost.cancel:cli'),
+    ('dedicatedhost:edit', 'SoftLayer.CLI.dedicatedhost.edit:cli'),
 
     ('cdn', 'SoftLayer.CLI.cdn'),
     ('cdn:detail', 'SoftLayer.CLI.cdn.detail:cli'),

--- a/tools/requirements.txt
+++ b/tools/requirements.txt
@@ -1,5 +1,5 @@
 requests >= 2.18.4
-click >= 5
+click >= 5, < 7
 prettytable >= 0.7.0
 six >= 1.7.0
 prompt_toolkit


### PR DESCRIPTION
1. Add new cli command to edit tags of dedicatedhost
2. Show tags in dedicatedhost detail
3. Filtered dedicatedhost via tag
e.g.
```
slcli dedicatedhost edit --tag nicetag 258803
slcli --format=json dedicatedhost detail 258803
{
    "modify date": "",
    "hostname": "dev-ryans-cluster0650-cluster-service-compute0-0",
    "cpu count": 56,
    "router hostname": "bcr01a.dal10",
    "memory capacity": 242,
    "tags": [
        "nicetag"
    ],
    "disk capacity": 1200,
    "guest count": 0,
    "create date": "2018-10-10T12:46:35-06:00",
    "router id": 843613,
    "owner": "1703415_mark+ibmdev@rescale.com_2018-08-02-13.24.01",
    "datacenter": "dal10",
    "id": 258803
}
```