### PR TITLE
Dedicatedhost#Cancel: cli bug with --immediate flag

### DIFF
--- a/SoftLayer/CLI/dedicatedhost/cancel.py
+++ b/SoftLayer/CLI/dedicatedhost/cancel.py
@@ -21,8 +21,8 @@ from SoftLayer.CLI import helpers
 @click.option('--reason',
               help="An optional cancellation reason. See cancel-reasons for a list of available options")
 @environment.pass_env
-def cli(env, identifier, comment, reason, immediate=True):
+def cli(env, identifier, immediate, comment, reason):
     """Cancel a dedicated server."""
-
+    immediate = True  # Enforce immediate cancellation
     mgr = SoftLayer.DedicatedHostManager(env.client)
     mgr.cancel_host(identifier, reason, comment, immediate)


### PR DESCRIPTION
We found weird behavior with cancellation if we set `--immediate default=True` in decorator.

`slcli dedicatedhost cancel ID`   => will create immediate cancellation ticket
`slcli dedicatedhost cancel ID --immediate` => will create non-immediate cancellation ticket
Have no idea what is the root cause, fix is to enforce `immediate = True` in function body.